### PR TITLE
Fixed invalid image URLs in asciidoc files

### DIFF
--- a/spec/src/main/asciidoc/batch-spec.adoc
+++ b/spec/src/main/asciidoc/batch-spec.adoc
@@ -18,7 +18,7 @@
 ifdef::backend-pdf[]
 :pagenums:
 :numbered:
-:title-logo-image: image:images/jakarta_ee_logo_schooner_color_stacked_default.png[pdfwidth=4.25in,align=right]
+:title-logo-image: image:jakarta_ee_logo_schooner_color_stacked_default.png[pdfwidth=4.25in,align=right]
 endif::[]
 
 == License

--- a/spec/src/main/asciidoc/domain_language.adoc
+++ b/spec/src/main/asciidoc/domain_language.adoc
@@ -23,7 +23,7 @@ and Java developers. JSR 352 specifies the layers, components and
 technical services commonly found in robust, maintainable systems used
 to address the creation of simple to complex batch applications.
 
-image::images/image003.png[image]
+image::image003.png[image]
 
 The diagram above highlights the key concepts that make up the domain
 language of batch. A Job has one to many steps, which has no more than
@@ -36,7 +36,7 @@ A Job is an entity that encapsulates an entire batch process. A Job
 will be wired together via a Job Specification Language. However, Job is
 just the top of an overall hierarchy:
 
-image::images/image005.png[http://static.springsource.org/spring-batch/trunk/reference/html-single/images/job-heirarchy.png]
+image::image005.png[http://static.springsource.org/spring-batch/trunk/reference/html-single/images/job-heirarchy.png]
 
 With JSR 352, a Job is simply a container for Steps. It combines
 multiple steps that belong logically together in a flow and allows for
@@ -104,7 +104,7 @@ rules that are applied as part of the processing. As with Job, a Step
 has an individual StepExecution that corresponds with a unique
 JobExecution:
 
-image::images/image007.png[http://static.springsource.org/spring-batch/trunk/reference/html-single/images/jobHeirarchyWithSteps.png]
+image::image007.png[http://static.springsource.org/spring-batch/trunk/reference/html-single/images/jobHeirarchyWithSteps.png]
 
 ==== StepExecution
 A StepExecution represents a single attempt to execute a Step. A new
@@ -163,7 +163,7 @@ an ItemProcessor, and aggregated. Once the number of items read equals
 the commit interval, the entire chunk is written out via the ItemWriter,
 and then the transaction is committed.
 
-image::images/image009.png[http://static.springsource.org/spring-batch/trunk/reference/html-single/images/chunk-oriented-processing.png]
+image::image009.png[http://static.springsource.org/spring-batch/trunk/reference/html-single/images/chunk-oriented-processing.png]
 
 === Batch Checkpoints
 


### PR DESCRIPTION
While generating documents from asciidoc, there is a warning about invalid URL for all images. The final output gets generated, but doesn't have the actual images. This pull request fixes that issue.