### PR TITLE
Update "Java EE" and Java SE version compatibility in spec doc

### DIFF
--- a/spec/src/main/asciidoc/applicability.adoc
+++ b/spec/src/main/asciidoc/applicability.adoc
@@ -1,2 +1,2 @@
 == Applicability of Specification
-This specification applies to Java SE and Java EE environments. It requires Java 6 or higher.
+This specification applies to Java SE and Jakarta EE environments. It requires Java 8 or higher.

--- a/spec/src/main/asciidoc/batch_programming_model.adoc
+++ b/spec/src/main/asciidoc/batch_programming_model.adoc
@@ -1755,7 +1755,7 @@ public interface Decider {
 === Transactionality
 
 Chunk type check points are transactional. The batch runtime uses global
-transaction mode on the Java EE platform and local transaction mode on
+transaction mode on the Jakarta EE platform and local transaction mode on
 the Java SE platform. Global transaction timeout is configurable at
 step-level with a step-level property:
 

--- a/spec/src/main/asciidoc/forward.adoc
+++ b/spec/src/main/asciidoc/forward.adoc
@@ -1,2 +1,2 @@
 == Foreword
-This specification describes the job specification language, Java programming model, and runtime environment for batch applications for the Java platform. It is designed for use on both the Java SE and Java EE platforms. Additionally, it is designed to work with dependency injection (DI) containers without prescribing a particular DI implementation.
+This specification describes the job specification language, Java programming model, and runtime environment for batch applications for the Java platform. It is designed for use on both the Java SE and Jakarta EE platforms. Additionally, it is designed to work with dependency injection (DI) containers without prescribing a particular DI implementation.


### PR DESCRIPTION
* Update "Java EE" to "Jakarta EE"
* Update Java SE compatibility version according to new requirement under "Java SE Version" here: https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan

gh-25

Signed-off-by: Thomas Vitale <development@thomasvitale.com>