### PR TITLE
 Issue #36 BatchRuntime.getJobOperator() method returns null in spec …

### DIFF
--- a/spec/src/main/asciidoc/batch_runtime_spec.adoc
+++ b/spec/src/main/asciidoc/batch_runtime_spec.adoc
@@ -826,12 +826,9 @@ public class BatchRuntime
     /**
     * The getJobOperator factory method returns
     * an instance of the JobOperator interface.
-    * *@return* JobOperator instance.
+    * @return JobOperator instance.
     */
-    public *static* JobOperator getJobOperator()
-    {
-        return null;
-    }
+    public static JobOperator getJobOperator() { ... }
 }
 ----
 


### PR DESCRIPTION
…document

Signed-off-by: Cheng Fang <cfang@redhat.com>