### PR TITLE
Package XSDs in API JAR

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -53,6 +53,13 @@
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>
+            <resource>
+                <directory>${project.basedir}/src/main/resources/jakarta/xml/batch</directory>
+                <includes>
+                    <include>*.xsd</include>
+                </includes>
+                <targetPath>xsd</targetPath>
+            </resource>
         </resources>
         <plugins>
             <plugin>


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

@mminella tagging you since you'd requested this change.   The schemas will get packaged via path /xsd from the API JAR root.

