### PR TITLE
Add cdi req

### DIFF
--- a/spec/src/main/asciidoc/acknowledgements.adoc
+++ b/spec/src/main/asciidoc/acknowledgements.adoc
@@ -7,7 +7,10 @@ A number of individuals deserve special recognition for their contributions to f
 * Mahesh Kannan
 * Scott Kurz
 * Wayne Lund
+* Romain Manni-Bucau
 * Simon Martinelli
+* Ondro Mihályi
 * Michael Minella
 * Kaushik Mukherjee
 * Joe Pullen
+* Reza Rahman

--- a/spec/src/main/asciidoc/batch_programming_model.adoc
+++ b/spec/src/main/asciidoc/batch_programming_model.adoc
@@ -1147,7 +1147,7 @@ JobListener, and so on.  @BatchProperty is used to assign batch artifact
 property values from Job XML to the batch artifact itself.
 
 Note that @BatchProperty is used with the standard @Inject annotation
-(jakarta.inject.Inject) and is "overloaded" for use in both CDI bean and
+(jakarta.inject.Inject) and is "overloaded" for use in both CDI Bean and
 batch-managed artifact instances (See section xref:batch-artifact-loading[10.5] 
 for more info).  There is substantial overlap across the two cases but there
 are also differences, as detailed in the sections below.
@@ -1203,7 +1203,7 @@ public @interface BatchProperty {
 ----
 
 Note the `@Qualifier` annotation present in the @BatchProperty definitions,
-for use in the case of CDI bean instances.
+for use in the case of CDI Bean instances.
 
 For batch-managed artifact instances, the value of the annotated field is 
 assigned by the batch runtime if a corresponding property element with a 
@@ -1240,7 +1240,7 @@ the String "123".
 A field annotated with the @BatchProperty annotation must not be static
 and must not be final.
 
-==== Scope of property definitions for @BatchProperty Injection
+==== Scope of property definitions for @BatchProperty injection
 
 The rules governing the definition of properties for injection via
 @BatchProperty deserve some extra explanation and an example.
@@ -1306,7 +1306,7 @@ users should not rely on consistent behaviors.
 Instead @BatchProperty injection points in the Java code should correspond to matching 
 non-empty property values in the JSL. 
 
-==== Additional requirements for CDI bean instances
+==== Additional requirements for CDI Bean instances
 
 ===== Bean
 
@@ -1375,7 +1375,7 @@ parent step/thread; there is a distinct StepContext for each sub-thread
 and each StepContext has its own distinct persistent user data for each
 sub-thread.
 
-===== Additional requirements for CDI bean instances
+===== Additional requirements for CDI Bean instances
 
 The batch runtime must ensure there is a producer for the batch context types with
 Dependent scope.

--- a/spec/src/main/asciidoc/batch_programming_model.adoc
+++ b/spec/src/main/asciidoc/batch_programming_model.adoc
@@ -1133,30 +1133,24 @@ model artifacts, then have values passed to them when a job is
 initiated. Batch properties are string values.
 
 Note batch properties are visible only in the scope in which they are
-defined (see Section xref:scope-of-property-definitions-for-batchproperty-injection[9.3.2]). However batch properties values can be
-formed from other properties according to Job XML Substitution Rules.
-See section xref:job-xml-substitution[8.8] for further information on substitution.
+defined (see Section xref:scope-of-property-definitions-for-batchproperty-injection[9.3.2]). However batch properties values can be formed from other properties 
+according to Job XML Substitution Rules.  See section xref:job-xml-substitution[8.8] 
+for further information on substitution.
 
 ==== @BatchProperty
 
-The @BatchProperty annotation identifies a class field injection as a
+The @BatchProperty annotation identifies an injection as a
 batch property. A batch property has a name (name) and default value.
-The @BatchProperty may be used on a class field for any class identified
+The @BatchProperty may be used for any class identified
 as a batch programming model artifact -E.g. ItemReader, ItemProcessor,
-JobListener, etc..
-
-@BatchProperty must be used with the standard @Inject annotation
-(jakarta.inject.Inject). @BatchProperty is used to assign batch artifact
+JobListener, and so on.  @BatchProperty is used to assign batch artifact
 property values from Job XML to the batch artifact itself.
 
-A field annotated with the @BatchProperty annotation must not be static
-and must not be final.
-
-Note: the batch runtime must ensure @Inject works with @BatchProperty,
-whether or not the execution environment includes an implementation of
-Jakarta Dependency Injection.   The batch properties must always be
-injected, and depending on the specific dependency injection technology
-used, other injections may or may not also be supported.
+Note that @BatchProperty is used with the standard @Inject annotation
+(jakarta.inject.Inject) and is "overloaded" for use in both CDI bean and
+batch-managed artifact instances (See section xref:batch-artifact-loading[10.5] 
+for more info).  There is substantial overlap across the two cases but there
+are also differences, as detailed in the sections below.
 
 Syntax:
 
@@ -1208,18 +1202,15 @@ public @interface BatchProperty {
 }
 ----
 
-The value of the annotated field is assigned by the batch runtime if a
-corresponding property element with a matching name is specified in the
-JSL in the scope that applies to the batch artifact in question. If the
-JSL property value resolves to the empty string (either explicitly set
-to the empty string literal or resolving to an empty string via property
-substitution, as described in section xref:job-xml-substitution[8.8]), no assignment is made and the resulting
-value is undefined by the batch specification. The resulting value might
-simply be the Java default value, however using various dependency
-injection technologies may produce different results. The resultant
-behavior may be defined by the particular dependency injection
-technology used in the runtime environment and so is outside the scope
-of this specification.
+Note the `@Qualifier` annotation present in the @BatchProperty definitions,
+for use in the case of CDI bean instances.
+
+For batch-managed artifact instances, the value of the annotated field is 
+assigned by the batch runtime if a corresponding property element with a 
+matching name is specified in the JSL in the scope that applies to the 
+batch artifact in question. 
+
+
 Example:
 
 [[app-listing.BatchPropertySample]]
@@ -1233,16 +1224,21 @@ Example:
 
 }
 ----
+[source,xml]
+----
+<property name="fname" value="123"/>
+----
 
 Behavior:
 
 When the batch runtime instantiates the batch artifact (item reader in
-this example), it assigns the
+this example), it assigns the value of the property with name equal to 'fname' 
+provided in the job XML to the corresponding @BatchProperty field named 'fname',
+the String "123".
 
-value of the property with name equal to fname provided in the job XML
-to the corresponding @BatchProperty field named fname. If no value is
-defined in JSL, the Java default (null) is assigned or some other
-default is provided by a particular dependency injection technology.
+===== Injection in Batch-managed instances
+A field annotated with the @BatchProperty annotation must not be static
+and must not be final.
 
 ==== Scope of property definitions for @BatchProperty Injection
 
@@ -1263,7 +1259,6 @@ step properties are themselves injectable into that artifact via
 properties are available for resolving the artifact-level property
 definitions via the jobProperties substitution mechanism (see section
  xref:jobproperties-substitution-operator[8.8.1.2]) .
-
 
 
 The following example should make this more clear:
@@ -1292,9 +1287,45 @@ The following example should make this more clear:
  // WONT WORK! - There is no property 'x' in scope for this injection
  @Inject @BatchProperty(name="x");
 
- // WILL WORK – Gets value 'xVal'
+ // WILL WORK - Gets value 'xVal'
  @Inject @BatchProperty(name="y");
 ----
+
+==== Unmatched property or empty property value does not necessarily get Java default value 
+
+If there is no matching JSL property for a given @BatchProperty name, or if the 
+corresponding JSL property has a value which resolves to the empty string (either 
+explicitly set to the empty string literal or resolving to an empty string via property
+substitution, as described in section xref:job-xml-substitution[8.8]), the resulting
+value is undefined by the batch specification. 
+
+It might be typical for a batch-managed instance to use the Java default value and
+a CDI implementation to set these @BatchProperty injection points to 'null', but
+users should not rely on consistent behaviors.   
+
+Instead @BatchProperty injection points in the Java code should correspond to matching 
+non-empty property values in the JSL. 
+
+==== Additional requirements for CDI bean instances
+
+===== Producer
+
+The batch runtime must ensure there is a producer for the BatchProperty-qualifier String type
+with Dependent scope.  It is left undefined whether the application can override with its own producer. 
+
+===== Properties for Dependent-scoped bean instances
+
+For Dependent-scoped bean instances, the batch runtime should ensure injection via producer
+of the properties in scope according to the rules in section xref:scope-of-property-definitions-for-batchproperty-injection[9.3.2].
+
+===== Properties for non-Dependent-scoped bean instances undefined
+
+For non-Dependent-scoped bean instances, the batch runtime cannot ensure property values that
+align with the JSL property values. Consider an `@ApplicationScoped` bean which may be created
+at application startup, before the batch runtime has even loaded any job definitions.
+
+Applications must use other methods besides @BatchProperty to parameterize such bean instances,
+in order to ensure support across batch implemenations.
 
 === Batch Contexts
 
@@ -1320,15 +1351,10 @@ E.g.:
 The batch runtime is responsible to ensure the correct context object is
 injected according to the job or step currently executing.
 
-Note: the batch runtime must ensure @Inject works with JobContext and
-StepContext, whether or not the execution environment includes an implementation of
-Jakarta Dependency Injection.  The batch contexts must always be
-injected, and depending on the specific dependency injection technology
-used, other injections may or may not also be supported.
- See section xref:jobcontext[10.9.1] for definition of JobContext class. See section
+See section xref:jobcontext[10.9.1] for definition of JobContext class. See section
 xref:stepcontext[10.9.2] for definition of StepContext class.
 
-===== Batch Context Lifecycle and Scope
+==== Batch Context Lifecycle and Scope
 
 A batch context has thread affinity and is visible only to the batch
 artifacts executing on that particular thread. A batch context injected
@@ -1348,6 +1374,21 @@ the step. For a partitioned step, there is one StepContext for the
 parent step/thread; there is a distinct StepContext for each sub-thread
 and each StepContext has its own distinct persistent user data for each
 sub-thread.
+
+===== Additional requirements for CDI bean instances
+
+The batch runtime must ensure there is a producer for the batch context types with
+Dependent scope.
+
+The batch runtime should cache these Dependent scope instances to provide a view
+of the instance scope to the application aligning with the above section.
+
+(It is left undefined whether the application can override with its own producer,
+but that would seem to contradict the value of leveraging a given batch implementation).
+
+
+
+
 
 === Parallelization
 

--- a/spec/src/main/asciidoc/batch_programming_model.adoc
+++ b/spec/src/main/asciidoc/batch_programming_model.adoc
@@ -1308,10 +1308,10 @@ non-empty property values in the JSL.
 
 ==== Additional requirements for CDI bean instances
 
-===== Producer
+===== Bean
 
-The batch runtime must ensure there is a producer for the BatchProperty-qualifier String type
-with Dependent scope.  It is left undefined whether the application can override with its own producer. 
+The batch runtime must ensure there is a Bean for the BatchProperty-qualifier String type
+with Dependent scope available for injection into batch artifact bean instances.
 
 ===== Properties for Dependent-scoped bean instances
 
@@ -1382,12 +1382,6 @@ Dependent scope.
 
 The batch runtime should cache these Dependent scope instances to provide a view
 of the instance scope to the application aligning with the above section.
-
-(It is left undefined whether the application can override with its own producer,
-but that would seem to contradict the value of leveraging a given batch implementation).
-
-
-
 
 
 === Parallelization

--- a/spec/src/main/asciidoc/batch_programming_model.adoc
+++ b/spec/src/main/asciidoc/batch_programming_model.adoc
@@ -1134,7 +1134,7 @@ initiated. Batch properties are string values.
 
 Note batch properties are visible only in the scope in which they are
 defined (see Section xref:scope-of-property-definitions-for-batchproperty-injection[9.3.2]). However batch properties values can be formed from other properties 
-according to Job XML Substitution Rules.  See section xref:job-xml-substitution[8.8] 
+according to Job XML Substitution Rules.  See section xref:job-xml-substitution[8.8]
 for further information on substitution.
 
 ==== @BatchProperty
@@ -1236,17 +1236,15 @@ this example), it assigns the value of the property with name equal to 'fname'
 provided in the job XML to the corresponding @BatchProperty field named 'fname',
 the String "123".
 
-===== Injection in Batch-managed instances
-A field annotated with the @BatchProperty annotation must not be static
-and must not be final.
 
-==== Scope of property definitions for @BatchProperty injection
+
+===== Scope of JSL Property Definitions for @BatchProperty Injection
 
 The rules governing the definition of properties for injection via
 @BatchProperty deserve some extra explanation and an example.
 
 For a given artifact, the only properties that are injectable via
-@BatchProperty are those which are defined at the level of the artifact
+@BatchProperty are those which are defined in JSL at the level of the artifact
 itself (i.e. as children of the "properties" element which is in turn a
 child of the very element defining the artifact: batchlet, reader,
 listener, etc.).
@@ -1274,7 +1272,7 @@ The following example should make this more clear:
  <step id="step1">
   <batchlet ref="MyBatchlet">
    <properties>
-    <property name="y" value="#\{jobProperties['x']}"/>
+    <property name="y" value="#{jobProperties['x']}"/>
    </properties>
 
 ----
@@ -1291,41 +1289,66 @@ The following example should make this more clear:
  @Inject @BatchProperty(name="y");
 ----
 
-==== Unmatched property or empty property value does not necessarily get Java default value 
+==== Requirements for Batch-Managed Batch Artifact Instances
 
-If there is no matching JSL property for a given @BatchProperty name, or if the 
-corresponding JSL property has a value which resolves to the empty string (either 
+A field annotated with the @BatchProperty annotation must not be static
+and must not be final.
+
+==== CDI-Related Batch Property Requirements
+
+===== CDI Bean Must Be Made Available
+
+On a batch execution thread, for a given batch property, the batch runtime must ensure there is a CDI Bean available with the @BatchProperty-qualifier String type, with the batch runtime providing one if necessary.
+
+Note this ensures that a batch artifact loaded as a CDI Bean (see section xref:batch-artifact-loading[10.5]) will have its
+@BatchProperty injection points satisfied, via the CDI implementation, with a CDI Bean for the batch property.
+
+===== Batch Property Values Resolved Based on "current batch artifact" on Thread
+
+A CDI Bean representing a batch property will obtain its String value based on the current thread of execution.
+
+This should not be surprising since two different batch artifacts each with a property named 'myPropName' might have different values,
+depending on how the property is defined in JSL in each artifact's `<properties>` definition.
+
+Once the batch runtime begins to load (see section xref:batch-artifact-loading[10.5]) a batch artifact, that particular artifact
+becomes the "current batch artifact" for the purpose of property resolution.
+
+Any batch property CDI Bean instances created on this same thread, with a given "current batch artifact" will have values defined
+via the jobProperties substitution mechanism (see section xref:jobproperties-substitution-operator[8.8.1.2]), and the set of batch properties
+available will be defined by the rules detailed in
+section xref:scope-of-property-definitions-for-batchproperty-injection[9.3.2.2] for this batch artifact.
+
+===== Consequences And Suggested Patterns
+
+As a consequence of the previous section, an application must be able to get a CDI Bean with a correct view of a batch property by either:
+
+* Statically injecting the batch property Bean into a @Dependent-scoped CDI Bean, (e.g. via a field injection of type: `@Inject @BatchProperty String` within a batch artifact loaded as a CDI Bean).  This assumes the artifact loading will occur on the execution thread.  
+   OR
+* Dynamically accessing the batch property bean via `jakarta.enterprise.inject.Instance#get()` or `javax.enterprise.inject.spi.CDI#select()` from the batch execution thread.
+
+On the other hand if a batch property Bean is statically injected into a normal-scoped Bean like an @ApplicationScoped batch artifact, the batch property Bean
+values may not accurately reflect the property based on the JSL scope associated with the current batch artifact.
+
+It is possible that the batch runtime will provide its batch property Beans with @Dependent-scope in order to implement the above, but strictly
+speaking that is an implementation detail.
+
+
+==== Undefined: unmatched property or empty property value does not necessarily get Java default value
+
+We call out a special, undefined case here.
+
+If there is no matching JSL property for a given @BatchProperty name, or if the
+corresponding JSL property has a value which resolves to the empty string (either
 explicitly set to the empty string literal or resolving to an empty string via property
 substitution, as described in section xref:job-xml-substitution[8.8]), the resulting
-value is undefined by the batch specification. 
+value is undefined by the batch specification.
 
 It might be typical for a batch-managed instance to use the Java default value and
 a CDI implementation to set these @BatchProperty injection points to 'null', but
-users should not rely on consistent behaviors.   
+users should not rely on consistent behaviors.
 
-Instead @BatchProperty injection points in the Java code should correspond to matching 
-non-empty property values in the JSL. 
-
-==== Additional requirements for CDI Bean instances
-
-===== Bean
-
-The batch runtime must ensure there is a Bean for the BatchProperty-qualifier String type
-with Dependent scope available for injection into batch artifact bean instances.
-
-===== Properties for Dependent-scoped bean instances
-
-For Dependent-scoped bean instances, the batch runtime should ensure injection via producer
-of the properties in scope according to the rules in section xref:scope-of-property-definitions-for-batchproperty-injection[9.3.2].
-
-===== Properties for non-Dependent-scoped bean instances undefined
-
-For non-Dependent-scoped bean instances, the batch runtime cannot ensure property values that
-align with the JSL property values. Consider an `@ApplicationScoped` bean which may be created
-at application startup, before the batch runtime has even loaded any job definitions.
-
-Applications must use other methods besides @BatchProperty to parameterize such bean instances,
-in order to ensure support across batch implemenations.
+Instead @BatchProperty injection points in the Java code should correspond to matching
+non-empty property values in the JSL.
 
 === Batch Contexts
 
@@ -1338,10 +1361,11 @@ injected into an application as member variables. There is a context for
 both job and step. The job context represents the entire job. The step
 context represents the current step executing within the job.
 
-==== Batch Contexts
+==== Batch Context Injection
 Batch artifact access to batch contexts is by injection using the
-standard @Inject annotation (jakarta.inject.Inject). A field into which a
-batch context is injected must not be static and must not be final.
+standard @Inject annotation (jakarta.inject.Inject). For a batch-managed (non-CDI Bean)
+artifact, a field into which a batch context is injected must not be static and must not be final.
+
 E.g.:
 
  @Inject JobContext _jctxt;
@@ -1354,12 +1378,18 @@ injected according to the job or step currently executing.
 See section xref:jobcontext[10.9.1] for definition of JobContext class. See section
 xref:stepcontext[10.9.2] for definition of StepContext class.
 
-==== Batch Context Lifecycle and Scope
+==== Batch Context Lifecycle and Scope - Logical View
 
 A batch context has thread affinity and is visible only to the batch
 artifacts executing on that particular thread. A batch context injected
-field may be null when out of scope. Each context type has a distinct
-scope and lifecycle as follows:
+field may be null when out of scope.
+
+We refer to this as the "logical view" of the context to reflect the fact
+that there are differences in the internal implementation details between the cases
+where the batch artifact is or is not loaded as a CDI Bean, since CDI of course
+has its own "scope" constructs.
+
+In the logical view, each context type has a distinct scope and lifecycle as follows:
 
 1.  JobContext +
 +
@@ -1375,13 +1405,29 @@ parent step/thread; there is a distinct StepContext for each sub-thread
 and each StepContext has its own distinct persistent user data for each
 sub-thread.
 
-===== Additional requirements for CDI Bean instances
+==== CDI-related Context Requirements
 
-The batch runtime must ensure there is a producer for the batch context types with
-Dependent scope.
+The batch runtime must ensure that on a batch execution thread, there is a CDI Bean available for each batch context type,
+with the batch runtime providing one if necessary.  A CDI Bean representing a batch context will obtain its backing values
+based on the current thread of execution, when the bean instance is created, providing the logical view of the context
+outlined in the previous section.
 
-The batch runtime should cache these Dependent scope instances to provide a view
-of the instance scope to the application aligning with the above section.
+Note this ensures that a batch artifact loaded as a CDI Bean (see section xref:batch-artifact-loading[10.5]) will have its
+batch context injection points satisfied, via the CDI implementation, with a CDI Bean for the batch context.
+
+===== Consequences And Suggested Patterns
+
+As a consequence of the previous section, an application must be able to get a CDI Bean with a correct view of the current contexts by either:
+
+* Statically injecting the context Bean into a @Dependent-scoped CDI Bean, (e.g. via a field injection of type: `@Inject JobContext` within a batch artifact loaded as a CDI Bean).  This assumes the artifact loading will occur on the execution thread).
+   OR
+* Dynamically accessing the context bean via `jakarta.enterprise.inject.Instance#get()` or `javax.enterprise.inject.spi.CDI#select()` from the batch execution thread.
+
+On the other hand if a context Bean is statically injected into a normal-scoped Bean like an @ApplicationScoped batch artifact, the context Bean
+values may not accurately reflect the logical context of the current execution thread.
+
+It is possible that the batch runtime will provide its context beans with @Dependent-scope in order to implement the above, but strictly
+speaking that is an implementation detail.
 
 
 === Parallelization

--- a/spec/src/main/asciidoc/batch_runtime_spec.adoc
+++ b/spec/src/main/asciidoc/batch_runtime_spec.adoc
@@ -155,7 +155,7 @@ The purpose of an implementation-specific loader is to enable Job XMLloading fro
 
 2.  archive class loader +
 +
-If the implementation-specific mechanism does fails to resolve a Job XML reference, then the batch runtime implementation must resolve the reference with an archive class loader. The implementation must provide an archive class loader that resolves the reference by looking up the reference
+If the implementation-specific mechanism fails to resolve a Job XML reference, then the batch runtime implementation must resolve the reference with an archive class loader. The implementation must provide an archive class loader that resolves the reference by looking up the reference
 from the `META-INF/batch-jobs` directory. +
 +
 Job XML documents may be packaged by the developer with the application under the `META-INF/batch-jobs` directory (`WEB-INF/classes/META-INF/batch-jobs` for .war files). +

--- a/spec/src/main/asciidoc/batch_runtime_spec.adoc
+++ b/spec/src/main/asciidoc/batch_runtime_spec.adoc
@@ -82,36 +82,20 @@ and then obtain a contextual reference for this bean for use by the batch runtim
 
 2. CDI Bean - using batch.xml mapping to fully qualified class name (FQCN)
 +
-The implementation must first provide an archive loader that looks up the reference in a `batch.xml` 
+The implementation must first provide an archive class loader that looks up the reference in a `batch.xml` 
 file, map this 'ref' value within `batch.xml` to a FQCN, and then obtain an instance of a Class object of
-this type using the archive loader.
+this type using the archive class loader.
 +
 The batch runtime must next obtain a CDI Bean instance, using this Class instance and the default qualifier
 from the current CDI context, (e.g. using `BeanManager.getBeans(Type beanType)`). 
 Finally, the batch runtime must obtain a contextual reference for this bean for use by the batch runtime.
 
-3. CDI Bean - using FQCN loaded by Thread Context Class Loader (TCCL)
-
-The implementation treats the 'ref' value as a FQCN and uses this class name to obtain an instance of a 
-Class object loaded by the TCCL.
+3. Batch-managed instance - using batch.xml mapping to fully qualified class name (FQCN)
 +
-Just as with 2., the batch runtime must next obtain a CDI Bean instance, using this Class instance and the default qualifier
-from the current CDI context, (e.g. using `BeanManager.getBeans(Type beanType)`). 
-Finally, the batch runtime must obtain a contextual reference for this bean for use by the batch runtime.
-
-4. Batch-managed instance - using batch.xml mapping to fully qualified class name (FQCN)
-
-The implementation must first provide an archive loader that looks up the reference in a `batch.xml` 
+The implementation must first provide an archive class loader that looks up the reference in a `batch.xml` 
 file, map this 'ref' value within `batch.xml` to a FQCN, and then obtain an instance of a Class object of
-this type using the archive loader. The batch runtime creates an instance of this class using a default or explicit no-arg
+this type using the archive class loader. The batch runtime creates an instance of this class using a default or explicit no-arg
 constructor.
-
-5. Batch-managed instance - using FQCN loaded by Thread Context Class Loader (TCCL)
-
-The implementation treats the 'ref' value as a FQCN and uses this class name to obtain an instance of a 
-Class object loaded by the TCCL.  The batch runtime creates an instance of this class using a default or explicit no-arg
-constructor.
-
 
 Notes:
 
@@ -169,9 +153,9 @@ The batch runtime implementation _must_ provide an implementation-specific means
 +
 The purpose of an implementation-specific loader is to enable Job XMLloading from outside of the application archive, such as from a repository, file system, remote cache, or elsewhere.
 
-2.  archive loader +
+2.  archive class loader +
 +
-If the implementation-specific mechanism does fails to resolve a Job XML reference, then the batch runtime implementation must resolve the reference with an archive loader. The implementation must provide an archive loader that resolves the reference by looking up the reference
+If the implementation-specific mechanism does fails to resolve a Job XML reference, then the batch runtime implementation must resolve the reference with an archive class loader. The implementation must provide an archive class loader that resolves the reference by looking up the reference
 from the `META-INF/batch-jobs` directory. +
 +
 Job XML documents may be packaged by the developer with the application under the `META-INF/batch-jobs` directory (`WEB-INF/classes/META-INF/batch-jobs` for .war files). +
@@ -189,7 +173,7 @@ method).
 
 ==== `META-INF/batch.xml`
 
-A batch application may use the archive loader (see section xref:batch-artifact-loading[10.5]) to
+A batch application may use the archive class loader (see section xref:batch-artifact-loading[10.5]) to
 load batch artifacts. The application can direct artifact loading by
 supplying an optional `batch.xml` file. The `batch.xml` file must be stored
 under the `META-INF` directory. For .jar files it is the standard `META-INF`
@@ -222,7 +206,7 @@ constructor ).
 
 ==== `META-INF/batch-jobs`
 
-A batch application may use the archive loader (see section xref:job-xml-loading[10.6]) to
+A batch application may use the archive class loader (see section xref:job-xml-loading[10.6]) to
 load Job XML documents. The application does this by storing the Job XML
 documents under the `META-INF/batch-jobs` directory. For .jar files the
 'batch-jobs' directory goes under the standard `META-INF` directory. For

--- a/spec/src/main/asciidoc/batch_runtime_spec.adoc
+++ b/spec/src/main/asciidoc/batch_runtime_spec.adoc
@@ -63,32 +63,97 @@ See section xref:batchruntime[10.9.5] for details on the BatchRuntime class.
 
 === Batch Artifact Loading
 
-All batch artifacts comprising a batch application are loadable by the
-following loaders in the order specified:
+By "artifact loading" we mean the process by which an instance of a batch API 
+interface or class is obtained by the batch runtime during the execution of the job, from
+the job definition.
 
-1.  Implementation-specific loader +
+In other words, this describes how a reference in a Job XML (using the 'ref' attribute) 
+is resolved to an instance of an implementation class.
+
+==== Required Artifact Loading Sequence
+
+Batch artifacts must be loaded in the order specified:
+
+1. CDI Bean - using 'ref' as EL name
 +
-The batch runtime implementation _may_ provide an
-implementation-specific means by which batch artifacts references in a Job XML (i.e. via the 'ref=' attribute) are resolved to an implementation class and instantiated. When the batch runtime resolves a batch artifact reference to an instance the implementation-specific mechanism (if one exists) is attempted first. The loader must return an
-instance or null. +
+The batch runtime must attempt to pass the 'ref' value as an EL bean name to the
+current CDI context, (e.g. using `BeanManager.getBeans(String name)` to obtain a CDI Bean instance, 
+and then obtain a contextual reference for this bean for use by the batch runtime.
+
+2. CDI Bean - using batch.xml mapping to fully qualified class name (FQCN)
 +
-An example of an implementation-specific loader might be CDI or Spring DI.
-2.  Archive loader +
+The implementation must first provide an archive loader that looks up the reference in a `batch.xml` 
+file, map this 'ref' value within `batch.xml` to a FQCN, and then obtain an instance of a Class object of
+this type using the archive loader.
 +
-If an implementation-specific mechanism does not exist or fails toresolve a batch artifact reference (returns null), then the batch
-runtime implementation must resolve the reference with an archive
-loader. The implementation must provide an archive loader that resolves
-the reference by looking up the reference in a `batch.xml` file, which
-maps reference name to implementation class name. The loader must return
-an instance or null. +
+The batch runtime must next obtain a CDI Bean instance, using this Class instance and the default qualifier
+from the current CDI context, (e.g. using `BeanManager.getBeans(Type beanType)`). 
+Finally, the batch runtime must obtain a contextual reference for this bean for use by the batch runtime.
+
+3. CDI Bean - using FQCN loaded by Thread Context Class Loader (TCCL)
+
+The implementation treats the 'ref' value as a FQCN and uses this class name to obtain an instance of a 
+Class object loaded by the TCCL.
 +
-The `batch.xml` file is packaged by the developer with the application under the '`META-INF`' directory ('`WEB-INF/classes/META-INF`' for .war files). +
-+
+Just as with 2., the batch runtime must next obtain a CDI Bean instance, using this Class instance and the default qualifier
+from the current CDI context, (e.g. using `BeanManager.getBeans(Type beanType)`). 
+Finally, the batch runtime must obtain a contextual reference for this bean for use by the batch runtime.
+
+4. Batch-managed instance - using batch.xml mapping to fully qualified class name (FQCN)
+
+The implementation must first provide an archive loader that looks up the reference in a `batch.xml` 
+file, map this 'ref' value within `batch.xml` to a FQCN, and then obtain an instance of a Class object of
+this type using the archive loader. The batch runtime creates an instance of this class using a default or explicit no-arg
+constructor.
+
+5. Batch-managed instance - using FQCN loaded by Thread Context Class Loader (TCCL)
+
+The implementation treats the 'ref' value as a FQCN and uses this class name to obtain an instance of a 
+Class object loaded by the TCCL.  The batch runtime creates an instance of this class using a default or explicit no-arg
+constructor.
+
+
+Notes:
+
+. For CDI loading, ambiguities are resolved normally
+. The `batch.xml` file is packaged by the developer with the application under the '`META-INF`' directory ('`WEB-INF/classes/META-INF`' for .war files).
 See xref:meta-infbatch-xml[10.7.1] for more about the `batch.xml` file.
 
-3.  Thread Context Class Loader +
-+
-If the archive loader fails to resolve a batch artifact reference (returns null), then the batch runtime implementation must resolve the reference by treating the reference as a class name and loading it through the thread context class loader. The loader must return an instance or null.
+==== Implementation-Specific Loading
+
+Finally, an implementation may in addition choose to provide an implementation-specific loading mechanism, as long
+as it supports the required artifact loading schemes.
+
+
+==== Instance Scope - one instance per JSL reference
+
+There are three scopes from the batch lifecycle scopes that pertain to artifact lifecycle: 
+job, step, and step-partition. No matter what type of artifact loading is used, the batch 
+runtime should obtain a single instance or reference from the artifact loader per JSL reference, 
+and then reuse that same instance for the life of the containing scope. (In the case of a partitioned 
+step, one instance or reference per Job XML reference per partition is obtained.)
+
+
+===== Instance Scope Examples
+
+To elaborate and clarify, consider a couple example cases:
+
+Case 1:  A StepListener annotated with the CDI `@Dependent` scope annotation.  
+
+In this case, a single instance is obtained in order to invoke the `beforeStep` method, and this same
+instance is resued by the batch runtime in order to invoke `afterStep`. Although `@Dependent` scope 
+implies a new instance is created by the CDI engine each time a bean instance is needed, the batch
+runtime only requests the single instance for the life of the step. 
+
+Case 2:  A step configured with two `<listener>` elements with the same FQCN 'ref' values, using batch-managed instances
+
+In this case, two different listener instances are instantiated by the batch runtime.  Although both 
+instances will be of the same type and execute in the same step scope, different instances are used.
+(Which makes sense since the only value in doing this is to use different properties on each instance.)
+
+
+===== Batch-Managed Instances Single-threaded
+In addition, a batch-managed instance loaded according to the steps 4 or 5, above, may not be shared across concurrent scopes. 
 
 === Job XML Loading
 
@@ -150,10 +215,7 @@ batch artifact implementation.
 |=======================================================================
 Notes:
 
-1. If an implementation-specific loader is used (see
-xref:batch-artifact-loading[10.5]) any artifact it loads takes precedence over artifacts specified in `batch.xml`.
-
-2. Use of `batch.xml` to load batch artifacts requires the
+1. Use of `batch.xml` to load batch artifacts requires the
 availability of a zero-argument constructor (either a default
 constructor or an explicitly-defined, no-arg
 constructor ).

--- a/spec/src/main/asciidoc/foreword.adoc
+++ b/spec/src/main/asciidoc/foreword.adoc
@@ -1,0 +1,4 @@
+== Foreword
+This specification describes the job specification language, Java programming model, and runtime environment for Jakarta Batch. It is designed for use on Jakarta EE platform implementations and in Java SE environments. 
+
+In the 2.1 version of this specification, we make a significant change in both defining the integration of Batch + Jakarta CDI and requiring support for this integration in order to achieve compliance. This represents a shift from the previous stance where we attempted to maintain a neutral view on the particular choice of Dependency Injection (DI) technology.  We make this change in order to take advantage of and better integrate with the full Jakarta platform.

--- a/spec/src/main/asciidoc/forward.adoc
+++ b/spec/src/main/asciidoc/forward.adoc
@@ -1,2 +1,0 @@
-== Foreword
-This specification describes the job specification language, Java programming model, and runtime environment for Jakarta Batch. It is designed for use on Jakarta EE platforms, and also in other Java SE environments. Additionally, it is designed to work with dependency injection (DI) containers without prescribing a particular DI implementation.

--- a/spec/src/main/asciidoc/jakarta-batch-spec.adoc
+++ b/spec/src/main/asciidoc/jakarta-batch-spec.adoc
@@ -26,7 +26,7 @@ include::license-efsl.adoc[]
 
 include::acknowledgements.adoc[]
 
-include::forward.adoc[]
+include::foreword.adoc[]
 
 == Table of Contents
 

--- a/spec/src/main/asciidoc/job_runtime_lifecycle.adoc
+++ b/spec/src/main/asciidoc/job_runtime_lifecycle.adoc
@@ -15,20 +15,9 @@ invocations. Simple symbols are used to denote actions as follows:
 
 === Batch Artifact Lifecycle
 
-All batch artifacts are instantiated prior to their use in the scope in
-which they are declared in the Job XML and are valid for the life of
-their containing scope. There are three scopes that pertain to artifact
-lifecycle: job, step, and step-partition.
-
-One artifact per Job XML reference is instantiated. In the case of a
-partitioned step, one artifact per Job XML reference per partition is
-instantiated. This means job level artifacts are valid for the life of
-the job. Step level artifacts are valid for the life of the step. Step
-level artifacts in a partition are valid for the life of the partition.
-
-No artifact instance may be shared across concurrent scopes. The same
-instance must be used in the applicable scope for a specific Job XML
-reference.
+The information in this section has been moved to section 
+xref:batch-artifact-loading[10.5], where a more complete specification of
+instance lifecycle incorporating CDI integration is provided.
 
 === Job Repository Artifact Lifecycle
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/batch-api/issues/46

Guide to reviewing:

* 3.Foreword 
   * Introduce the change to require CDI
* 9.3 Batch Properties
   * refactored the property stuff to be used for both batch-mgd and CDI dependent scope
   * added a note on producers.. left undefined if a user adds own producer
   * mentioned it was undefined to use properties on non-Dependent scope
   * refactored the no matching property or empty property value discussion (was this only supposed to be about empty 
  property values?  Did I wrongly add the "no matching property" use case???  Will have to check)
 * 9.4 Batch Contexts
    *  Tried to leverage the existing scope definitions and say that the batch runtime would provide a similar scope view even for a Dependent-scoped bean
    *  Undefined if user adds own producer
 * 10.5. Batch Artifact Loading
   *  Added the 1-5 sequence : CDI name, CDI batch.xml, CDI FQCN, batch-mgd batch.xml, batch-mgd FQCN
   * Clarified that using CDI with FQCN implied default classifier .. normal ambiguity resolution
   * Added some scope examples to illustrate one instance per JSL ref
   * I don't see the point of saying the impl-specific load should happen first?   Isn't this untestable?


Finally, I might have messed up some links , section refs so please keep an eye out for that.