### PR TITLE
Adust language around "dynamic" batch property access per TCK challenge issue #71

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ more.
 
 The project maintains the following source code repositories:
 
-https://github.com/eclipse-ee4j/batch-api
-https://github.com/eclipse-ee4j/batch-tck
+https://github.com/jakartaee/batch
+https://github.com/jakartaee/batch-tck
 
 ## Eclipse Contributor Agreement
 

--- a/NOTICE
+++ b/NOTICE
@@ -26,8 +26,8 @@ SPDX-License-Identifier: Apache-2.0
 
 The project maintains the following source code repositories:
 
-https://github.com/eclipse-ee4j/batch-api
-https://github.com/eclipse-ee4j/batch-tck
+https://github.com/jakartaee/batch
+https://github.com/jakartaee/batch-tck
 
 ## Third-party Content
 

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ This specification describes the job specification language, Java programming mo
 https://projects.eclipse.org/projects/ee4j.batch/contact 
 
 ## Contribute
-[Contribution Guide](https://github.com/eclipse-ee4j/batch-api/blob/master/CONTRIBUTING.md)
+[Contribution Guide](https://github.com/jakartaee/batch/blob/master/CONTRIBUTING.md)

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         Batch workloads have common requirements, especially operational control, which allow for initiation
         of, and interaction with, batch instances; such interactions include stop and restart.
     </description>
-    <url>https://github.com/eclipse-ee4j/batch-api</url>
+    <url>https://github.com/jakartaee/batch</url>
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -54,9 +54,9 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:https://github.com/eclipse-ee4j/batch-api.git</connection>
-        <developerConnection>scm:git:https://github.com/eclipse-ee4j/batch-api.git</developerConnection>
-        <url>https://github.com/eclipse-ee4j/batch-api</url>
+        <connection>scm:git:https://github.com/jakartaee/batch.git</connection>
+        <developerConnection>scm:git:https://github.com/jakartaee/batch.git</developerConnection>
+        <url>https://github.com/jakartaee/batch</url>
         <tag>HEAD</tag>
     </scm>
 

--- a/spec/src/main/asciidoc/batch_programming_model.adoc
+++ b/spec/src/main/asciidoc/batch_programming_model.adoc
@@ -1393,7 +1393,7 @@ As a consequence of the previous section, an application must be able to get a C
 
 * Injecting the batch property Bean into a @Dependent-scoped CDI Bean via any standard CDI mechanism, (e.g. via a field injection of type: `@Inject @BatchProperty String` within a batch artifact loaded as a CDI Bean).  This assumes the artifact loading will occur on the execution thread.  
    OR
-* Dynamically accessing the batch property bean via `jakarta.enterprise.inject.Instance#get()` or `javax.enterprise.inject.spi.CDI#select()` from the batch execution thread.
+* Dynamically accessing the batch property bean via `jakarta.enterprise.inject.Instance#get()` from the batch execution thread.
 
 On the other hand if a batch property Bean is statically injected into a normal-scoped Bean like an @ApplicationScoped batch artifact, the batch property Bean
 values may not accurately reflect the property based on the JSL scope associated with the current batch artifact.

--- a/spec/src/main/asciidoc/change_log.adoc
+++ b/spec/src/main/asciidoc/change_log.adoc
@@ -10,7 +10,7 @@ The most important changes were done in issue:
 
 [width="100%",cols="15%,85%",]
 |=======================================================================
-|https://github.com/eclipse-ee4j/batch-api/issues/46[Issue 46] |Require precedence given to loading batch artifacts as CDI Beans
+|https://github.com/jakartaee/batch/issues/46[Issue 46] |Require precedence given to loading batch artifacts as CDI Beans
 |=======================================================================
 
 We also defined several additional details of the Jakarta Batch + CDI integration in the list below:
@@ -19,19 +19,19 @@ We also defined several additional details of the Jakarta Batch + CDI integratio
 
 [width="100%",cols="15%,85%",]
 |=======================================================================
-|https://github.com/eclipse-ee4j/batch-api/issues/17[Issue 17] | Support for CDI injection of JobOperator
-|https://github.com/eclipse-ee4j/batch-api/issues/43[Issue 43] | Support @BatchProperty injection into several primitive wrapper type elements
-|https://github.com/eclipse-ee4j/batch-api/issues/46[Issue 46] | Require precedence given to loading batch artifacts as CDI Beans
-|https://github.com/eclipse-ee4j/batch-api/issues/50[Issue 50] | Support @BatchProperty injection into method parameter and constructor parameter elements for CDI Beans
-|https://github.com/eclipse-ee4j/batch-api/issues/132[Issue 132] | Clarify injection of batch properties and contexts can be done in CDI Beans loaded via "current" batch artifact, e.g. see xref:batch-property-values-resolved-based-on-current-batch-artifact-on-thread[here]
-|https://github.com/eclipse-ee4j/batch-api/issues/190[Issue 190] | Define precedence of app-provided JobOperator Bean over runtime-provided Bean
+|https://github.com/jakartaee/batch/issues/17[Issue 17] | Support for CDI injection of JobOperator
+|https://github.com/jakartaee/batch/issues/43[Issue 43] | Support @BatchProperty injection into several primitive wrapper type elements
+|https://github.com/jakartaee/batch/issues/46[Issue 46] | Require precedence given to loading batch artifacts as CDI Beans
+|https://github.com/jakartaee/batch/issues/50[Issue 50] | Support @BatchProperty injection into method parameter and constructor parameter elements for CDI Beans
+|https://github.com/jakartaee/batch/issues/132[Issue 132] | Clarify injection of batch properties and contexts can be done in CDI Beans loaded via "current" batch artifact, e.g. see xref:batch-property-values-resolved-based-on-current-batch-artifact-on-thread[here]
+|https://github.com/jakartaee/batch/issues/190[Issue 190] | Define precedence of app-provided JobOperator Bean over runtime-provided Bean
 |=======================================================================
 
 ==== Other misc. issues
 [width="100%",cols="15%,85%",]
 |=======================================================================
-|https://github.com/eclipse-ee4j/batch-api/issues/117[Issue 117] | Added missing xref:job-level-listener-properties[section] for Job Level Listener Properties
-|https://github.com/eclipse-ee4j/batch-api/issues/36[Issue 36] | BatchRuntime.getJobOperator() method returns null in spec document
+|https://github.com/jakartaee/batch/issues/117[Issue 117] | Added missing xref:job-level-listener-properties[section] for Job Level Listener Properties
+|https://github.com/jakartaee/batch/issues/36[Issue 36] | BatchRuntime.getJobOperator() method returns null in spec document
 |=======================================================================
 
 === Version 1.0 Revision A - Maintenance Release


### PR DESCRIPTION
Fixes #209.  (Also use this as an opportunity to update the repo URLs since we moved to the 'jakartaee' GitHub org)

For your review:  @Azquelt @rmannibucau  @rzo1
(you can ignore the link rename and just look at the 2nd [commit](https://github.com/jakartaee/batch/pull/211/commits/f45d9d5215fea72e490de43f1efee8ce3a6f8862))
### Response to Suggestions

@rzo1, I did read your suggestions:  https://github.com/jakartaee/batch/issues/209#issuecomment-1969807221
for related updates.

So, we do have the special case https://github.com/jakartaee/batch/blob/master/spec/src/main/asciidoc/batch_programming_model.adoc#method-parameter-and-constructor-parameter-injection-with-explicit-name: 

> A key difference vs. field injection, however, is that method and constructor parameter injection are not required to support the default batch property name like it is calculated from the field name in field injection. A method or constructor parameter @BatchProperty annotation must explicitly include a 'name' attribute specifying the batch property name.   

This is maybe a bit unusual.. and maybe is a legacy of the original spec's stance that it wouldn't require CDI (though we've more recently decided to embrace CDI).

But I feel like we don't especially need to go any further here.  

If we do there is a decent chance we'll miss some other place with similar language where we should've similarly updated.  
Plus we end up just re-documenting CDI itself the further we go.   

What's there has already been approved...presumably what's there is more helpful than confusing at the moment...except for this small piece I'm changing.

Thanks though, and please see what you think.








